### PR TITLE
Safe division for `buffer_size_in_rows`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrow-odbc"
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Markus Klein"]
 edition = "2021"
 license = "MIT"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.1
+
+* Prevent division by zero errors when using `OdbcReaderBuilder::buffer_size_in_rows` on empty schemas.
+
 ## 3.1.0
 
 * Update arrow `>= 29, < 49` -> `>= 29, < 50`

--- a/src/reader/odbc_reader.rs
+++ b/src/reader/odbc_reader.rs
@@ -463,16 +463,19 @@ impl OdbcReaderBuilder {
 
     /// No matter if the user explicitly specified a limit in row size, a memory limit, both or
     /// neither. In order to construct a reader we need to decide on the buffer size in rows.
-    /// If a schema is empty, return something non-zero to be allocated.
     fn buffer_size_in_rows(&self, bytes_per_row: usize) -> Result<usize, Error> {
-        let check_rows_per_batch = self.max_bytes_per_batch.checked_div(bytes_per_row);
-        match check_rows_per_batch {
-            Some(0) => Err(Error::OdbcBufferTooSmall {
+        // If schema is empty, return before division by zero error.
+        if bytes_per_row == 0 {
+            return Ok(self.max_bytes_per_batch)
+        }
+        let rows_per_batch = self.max_bytes_per_batch / bytes_per_row;
+        if rows_per_batch == 0 {
+            Err(Error::OdbcBufferTooSmall {
                 max_bytes_per_batch: self.max_bytes_per_batch,
                 bytes_per_row,
-            }),
-            Some(rows_per_batch) => Ok(min(self.max_num_rows_per_batch, rows_per_batch)),
-            None => Ok(self.max_num_rows_per_batch),
+            })
+        } else {
+            Ok(min(self.max_num_rows_per_batch, rows_per_batch))
         }
     }
 


### PR DESCRIPTION
Changed `buffer_size_in_rows` to use safe division so empty schema on subsequent results don't panic.