### PR TITLE
expose the `iodbc` feature flag on the arrow-odbc crate 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,5 @@ stdext = "0.3.1"
 float_eq = "1.0.1"
 
 
-[target.'cfg(not(target_os = "windows"))'.features]
+[features]
 iodbc = ["odbc-api/iodbc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,6 @@ lazy_static = "1.4.0"
 stdext = "0.3.1"
 float_eq = "1.0.1"
 
-[features]
+
+[target.'cfg(not(target_os = "windows"))'.features]
+iodbc = ["odbc-api/iodbc"]


### PR DESCRIPTION
we're trying to get iodbc to work on mac. We would use unixodbc but snowflake provides a driver only for iodbc on mac. We use arrow types extensively, so would be great if we can get iodbc + arrow working here. 

This PR adds the iodbc feature to this crate to expose the feature on the odbc-api crate. 