### PR TITLE
When setting a max binary/text size, choose the larger value?

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, sync::Arc};
+use std::{cmp::max, convert::TryInto, sync::Arc};
 
 use arrow::{
     array::{ArrayRef, BooleanBuilder},
@@ -169,13 +169,7 @@ pub fn choose_column_strategy(
                 (None, None) => return Err(ColumnFailure::ZeroSizedColumn { sql_type }),
                 (None, Some(limit)) => limit,
                 (Some(len), None) => len.get(),
-                (Some(len), Some(limit)) => {
-                    if len.get() < limit {
-                        len.get()
-                    } else {
-                        limit
-                    }
-                }
+                (Some(len), Some(limit)) => max(len.get(), limit)
             };
             Box::new(Binary::new(length))
         }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -169,7 +169,7 @@ pub fn choose_column_strategy(
                 (None, None) => return Err(ColumnFailure::ZeroSizedColumn { sql_type }),
                 (None, Some(limit)) => limit,
                 (Some(len), None) => len.get(),
-                (Some(len), Some(limit)) => max(len.get(), limit)
+                (Some(len), Some(limit)) => max(len.get(), limit),
             };
             Box::new(Binary::new(length))
         }

--- a/src/reader/text.rs
+++ b/src/reader/text.rs
@@ -1,4 +1,4 @@
-use std::{char::decode_utf16, cmp::{max}, ffi::CStr, num::NonZeroUsize, sync::Arc};
+use std::{char::decode_utf16, cmp::max, ffi::CStr, num::NonZeroUsize, sync::Arc};
 
 use arrow::array::{ArrayRef, StringBuilder};
 use log::warn;

--- a/src/reader/text.rs
+++ b/src/reader/text.rs
@@ -1,4 +1,4 @@
-use std::{char::decode_utf16, cmp::min, ffi::CStr, num::NonZeroUsize, sync::Arc};
+use std::{char::decode_utf16, cmp::{max}, ffi::CStr, num::NonZeroUsize, sync::Arc};
 
 use arrow::array::{ArrayRef, StringBuilder};
 use log::warn;
@@ -23,7 +23,7 @@ pub fn choose_text_strategy(
         (None, None) => Err(ColumnFailure::ZeroSizedColumn { sql_type }),
         (None, Some(limit)) => Ok(limit),
         (Some(len), None) => Ok(len),
-        (Some(len), Some(limit)) => Ok(min(len, limit)),
+        (Some(len), Some(limit)) => Ok(max(len, limit)),
     };
     let strategy: Box<dyn ReadStrategy + Send> = if cfg!(target_os = "windows") {
         let hex_len = sql_type

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1996,7 +1996,9 @@ fn sanatize_column_names() {
         .connect_with_connection_string(MSSQL, Default::default())
         .unwrap();
     let drop_table = &format!("DROP TABLE IF EXISTS {table_name}");
-    let create_table = format!("CREATE TABLE {table_name} (id int IDENTITY(1,1),\"column name with spaces\" INTEGER);");
+    let create_table = format!(
+        "CREATE TABLE {table_name} (id int IDENTITY(1,1),\"column name with spaces\" INTEGER);"
+    );
     conn.execute(drop_table, ()).unwrap();
     conn.execute(&create_table, ()).unwrap();
     let array = Int32Array::from(vec![Some(42)]);


### PR DESCRIPTION
Hello! Thank you for these crates, it was really easy to get up and running!!

I am trying to read an ODBC data source ([Simba/Databricks](https://www.databricks.com/spark/odbc-drivers-download)) from a columnar store that has a particularly large column (a file, potentially several megabytes). Unfortunately, something is wrong with the result set metadata, where the reported result set column size is too small for the values returned. This also happens with large text columns (e.g. base64 representation of bytes):

Bin case:
```
Varbinary { length: Some(32767) }
called `Result::unwrap()` on an `Err` value: ArrowError { source: ExternalError(TooLargeValueForBuffer { indicator: Some(73456), buffer_index: 3 }) }
```

Text case: result set metadata is e.g. `Varchar(255)` for 10k+ of text.

---
EDIT: Bummer, looks like the driver provided metadata is incorrect:

Query `select raw_email from messages`

```rust
statement.execute().unwrap();
let mut desc = ColumnDescription::default();
statement.describe_col(1, &mut desc);
```

```
ColumnDescription { name: [114, 97, 119, 95, 101, 109, 97, 105, 108], data_type: Varbinary { length: Some(32767) }, nullability: Nullable }

thread 'tokio-runtime-worker' panicked at crates/db_connection_pool/src/dbconnection/odbcconn.rs:142:78:
called `Result::unwrap()` on an `Err` value: ArrowError { source: ExternalError(TooLargeValueForBuffer { indicator: Some(842374), buffer_index: 0 }) }
```

Is it correct to assume the metadata is coming from [`sql_describe_col`](https://docs.rs/odbc-api/7.0.0/src/odbc_api/handles/statement.rs.html#286) and by extension from the driver?

---

I understand the semantics as written are to choose an upper bound (which this undoes for large results with accurate size), but wanted to ask if there could be an affordance made for choosing the _larger_ one of the two (maybe a `Quirk` like "result_set_alloc_max_sizes")? With this change I am able to read result batches fine. But in the case that the buffer is too small, we cannot proceed. I will try to assemble some test case data, I figure this is enough to start the conversation 😸.
