### PR TITLE
feat: handle invalid UTF-8 bytes received from ODBC drivers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,9 @@ stdext = "0.3.3"
 float_eq = "1.0.1"
 
 [features]
+
+## For Apple Silicon users who installed unixodbc via:
+##    `brew install unixodbc`
+## This allows them to build the crate. 
+[target.'cfg(target_arch = "aarch64")'.build]
+rustflags = ["-L/opt/homebrew/lib", "-I/opt/homebrew/include"]


### PR DESCRIPTION
I am not 100% sure if this is an optimal solution, but I think it would be good to handle invalid UTF-8 from the ODBC drivers somehow, and lossily converting them was the best I could think of so far.

Or, at least not panic, as it will kill a Python session when reading from a database and the table contains some non-UTF-8 bytes. 

Note: I also included some `rustflags` in the Cargo.toml for Apple Silicon users who've installed `unixodbc` via Homebrew. 

Edit: I haven't tested it with the test suite yet, as the MSSQL image doesn't run on my laptop.